### PR TITLE
Fix sample rate conversion buffer sizing

### DIFF
--- a/src/waveguide/src/config.cpp
+++ b/src/waveguide/src/config.cpp
@@ -1,6 +1,7 @@
 #include "waveguide/config.h"
 
 #include <cmath>
+#include <stdexcept>
 
 #include "samplerate.h"
 
@@ -35,7 +36,9 @@ util::aligned::vector<float> adjust_sampling_rate(const float* data,
                 "Sample rate of 0 gives few hints about how to proceed."};
     }
     const auto ratio = out_sr / in_sr;
-    util::aligned::vector<float> out_signal(ratio * size);
+    const auto output_size = static_cast<size_t>(
+            std::ceil(ratio * static_cast<double>(size)));
+    util::aligned::vector<float> out_signal(output_size);
     SRC_DATA sample_rate_info{data,
                               out_signal.data(),
                               static_cast<long>(size),
@@ -44,7 +47,13 @@ util::aligned::vector<float> adjust_sampling_rate(const float* data,
                               0,
                               0,
                               ratio};
-    src_simple(&sample_rate_info, SRC_SINC_BEST_QUALITY, 1);
+    const auto error = src_simple(&sample_rate_info, SRC_SINC_BEST_QUALITY, 1);
+    if (error != 0) {
+        throw std::runtime_error{src_strerror(error)};
+    }
+
+    out_signal.resize(
+            static_cast<size_t>(sample_rate_info.output_frames_gen));
 
     //  Correct output level.
     const auto volume_scale = 1 / ratio;

--- a/src/waveguide/tests/sample_rate_conversion.cpp
+++ b/src/waveguide/tests/sample_rate_conversion.cpp
@@ -1,45 +1,63 @@
 #include "waveguide/config.h"
 
-#include "audio_file/audio_file.h"
-
-#include "utilities/string_builder.h"
-
 #include "gtest/gtest.h"
+
+#include <algorithm>
+#include <cmath>
+#include <vector>
 
 namespace {
 
-template <typename T>
-void scale_and_write(double scale,
-                     const char* fname,
-                     const T& data,
-                     double sample_rate) {
-    auto copy{data};
-    for (auto& i : copy) {
-        i *= scale;
-    }
-
-    audio_file::write(
-            util::build_string(sample_rate, '.', fname, ".wav").c_str(),
-            copy,
-            sample_rate,
-            audio_file::format::wav,
-            audio_file::bit_depth::pcm16);
+std::vector<float> make_impulse(size_t size, size_t impulse_index) {
+    std::vector<float> signal(size, 0.0f);
+    signal.at(impulse_index) = 1.0f;
+    return signal;
 }
 
 }  // namespace
 
-TEST(sample_rate_conversion, convert) {
-    std::vector<float> input(1000, 0.0);
-    input[200] = 1.0;
-    const auto input_sr = 1000;
-    const auto output_sr = 2000;
+TEST(sample_rate_conversion, impulse_resampling) {
+    constexpr size_t impulse_index = 200;
+    constexpr size_t input_size = 1000;
+    constexpr double input_sr = 1000.0;
 
-    const auto scale = 0.1;
+    const auto input = make_impulse(input_size, impulse_index);
 
-    scale_and_write(scale, "impulse", input, input_sr);
+    // Upsampling by a factor of two should double the frame count and keep
+    // the impulse amplitude after gain correction.
+    constexpr double upsampled_sr = 2000.0;
+    const auto upsampled = wayverb::waveguide::adjust_sampling_rate(
+            input, input_sr, upsampled_sr);
 
-    const auto output = wayverb::waveguide::adjust_sampling_rate(
-            input, input_sr, output_sr);
+    const auto expected_up_size = static_cast<size_t>(input_size * 2);
+    ASSERT_EQ(upsampled.size(), expected_up_size);
 
-    scale_and_write(scale, "impulse", output, output_sr);
+    const auto upsampled_max = std::abs(*std::max_element(
+            upsampled.begin(),
+            upsampled.end(),
+            [](float lhs, float rhs) {
+                return std::abs(lhs) < std::abs(rhs);
+            }));
+    const auto expected_up_amplitude = static_cast<float>(
+            std::min(1.0, input_sr / upsampled_sr));
+    EXPECT_NEAR(upsampled_max, expected_up_amplitude, 5e-2f);
+
+    // Downsampling by a factor of two should halve the frame count and retain
+    // the impulse amplitude.
+    constexpr double downsampled_sr = 500.0;
+    const auto downsampled = wayverb::waveguide::adjust_sampling_rate(
+            input, input_sr, downsampled_sr);
+
+    const auto expected_down_size = static_cast<size_t>(input_size / 2);
+    ASSERT_EQ(downsampled.size(), expected_down_size);
+
+    const auto downsampled_max = std::abs(*std::max_element(
+            downsampled.begin(),
+            downsampled.end(),
+            [](float lhs, float rhs) {
+                return std::abs(lhs) < std::abs(rhs);
+            }));
+    const auto expected_down_amplitude = static_cast<float>(
+            std::min(1.0, input_sr / downsampled_sr));
+    EXPECT_NEAR(downsampled_max, expected_down_amplitude, 5e-2f);
 }


### PR DESCRIPTION
## Summary
- ensure `adjust_sampling_rate` allocates enough space for resampled frames, checks the libsamplerate return code, and trims the buffer before applying gain
- extend the sample rate conversion regression test to cover up/down conversions and validate frame counts and amplitudes

## Testing
- ./temp_test


------
https://chatgpt.com/codex/tasks/task_e_68e0d9ad8d4c832ab808769d8d01b550